### PR TITLE
refactor: add Python API

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,6 +5,7 @@ docker = "*"
 requests = "*"
 tqdm = "*"
 python-dateutil = "*"
+pandas = ">=1.0.0"
 
 [dev-packages]
 nose = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "fc5141b40a5272c3770e2f2e701026b2aaf5aa15a5c46ee6ec0305e73f2ea839"
+            "sha256": "f6ce2fc210224cc19d3e0e137e92a4173801b702abf1c32f4c0a600733ea2d36"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -66,6 +66,54 @@
             ],
             "version": "==2.9"
         },
+        "numpy": {
+            "hashes": [
+                "sha256:00d7b54c025601e28f468953d065b9b121ddca7fff30bed7be082d3656dd798d",
+                "sha256:02ec9582808c4e48be4e93cd629c855e644882faf704bc2bd6bbf58c08a2a897",
+                "sha256:0e6f72f7bb08f2f350ed4408bb7acdc0daba637e73bce9f5ea2b207039f3af88",
+                "sha256:1be2e96314a66f5f1ce7764274327fd4fb9da58584eaff00b5a5221edefee7d6",
+                "sha256:2466fbcf23711ebc5daa61d28ced319a6159b260a18839993d871096d66b93f7",
+                "sha256:2b573fcf6f9863ce746e4ad00ac18a948978bb3781cffa4305134d31801f3e26",
+                "sha256:3f0dae97e1126f529ebb66f3c63514a0f72a177b90d56e4bce8a0b5def34627a",
+                "sha256:50fb72bcbc2cf11e066579cb53c4ca8ac0227abb512b6cbc1faa02d1595a2a5d",
+                "sha256:57aea170fb23b1fd54fa537359d90d383d9bf5937ee54ae8045a723caa5e0961",
+                "sha256:709c2999b6bd36cdaf85cf888d8512da7433529f14a3689d6e37ab5242e7add5",
+                "sha256:7d59f21e43bbfd9a10953a7e26b35b6849d888fc5a331fa84a2d9c37bd9fe2a2",
+                "sha256:904b513ab8fbcbdb062bed1ce2f794ab20208a1b01ce9bd90776c6c7e7257032",
+                "sha256:96dd36f5cdde152fd6977d1bbc0f0561bccffecfde63cd397c8e6033eb66baba",
+                "sha256:9933b81fecbe935e6a7dc89cbd2b99fea1bf362f2790daf9422a7bb1dc3c3085",
+                "sha256:bbcc85aaf4cd84ba057decaead058f43191cc0e30d6bc5d44fe336dc3d3f4509",
+                "sha256:dccd380d8e025c867ddcb2f84b439722cf1f23f3a319381eac45fd077dee7170",
+                "sha256:e22cd0f72fc931d6abc69dc7764484ee20c6a60b0d0fee9ce0426029b1c1bdae",
+                "sha256:ed722aefb0ebffd10b32e67f48e8ac4c5c4cf5d3a785024fdf0e9eb17529cd9d",
+                "sha256:efb7ac5572c9a57159cf92c508aad9f856f1cb8e8302d7fdb99061dbe52d712c",
+                "sha256:efdba339fffb0e80fcc19524e4fdbda2e2b5772ea46720c44eaac28096d60720",
+                "sha256:f22273dd6a403ed870207b853a856ff6327d5cbce7a835dfa0645b3fc00273ec"
+            ],
+            "version": "==1.18.4"
+        },
+        "pandas": {
+            "hashes": [
+                "sha256:07c1b58936b80eafdfe694ce964ac21567b80a48d972879a359b3ebb2ea76835",
+                "sha256:0ebe327fb088df4d06145227a4aa0998e4f80a9e6aed4b61c1f303bdfdf7c722",
+                "sha256:11c7cb654cd3a0e9c54d81761b5920cdc86b373510d829461d8f2ed6d5905266",
+                "sha256:12f492dd840e9db1688126216706aa2d1fcd3f4df68a195f9479272d50054645",
+                "sha256:167a1315367cea6ec6a5e11e791d9604f8e03f95b57ad227409de35cf850c9c5",
+                "sha256:1a7c56f1df8d5ad8571fa251b864231f26b47b59cbe41aa5c0983d17dbb7a8e4",
+                "sha256:1fa4bae1a6784aa550a1c9e168422798104a85bf9c77a1063ea77ee6f8452e3a",
+                "sha256:32f42e322fb903d0e189a4c10b75ba70d90958cc4f66a1781ed027f1a1d14586",
+                "sha256:387dc7b3c0424327fe3218f81e05fc27832772a5dffbed385013161be58df90b",
+                "sha256:6597df07ea361231e60c00692d8a8099b519ed741c04e65821e632bc9ccb924c",
+                "sha256:743bba36e99d4440403beb45a6f4f3a667c090c00394c176092b0b910666189b",
+                "sha256:858a0d890d957ae62338624e4aeaf1de436dba2c2c0772570a686eaca8b4fc85",
+                "sha256:863c3e4b7ae550749a0bb77fa22e601a36df9d2905afef34a6965bed092ba9e5",
+                "sha256:a210c91a02ec5ff05617a298ad6f137b9f6f5771bf31f2d6b6367d7f71486639",
+                "sha256:ca84a44cf727f211752e91eab2d1c6c1ab0f0540d5636a8382a3af428542826e",
+                "sha256:d234bcf669e8b4d6cbcd99e3ce7a8918414520aeb113e2a81aeb02d0a533d7f7"
+            ],
+            "index": "pypi",
+            "version": "==1.0.3"
+        },
         "python-dateutil": {
             "hashes": [
                 "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
@@ -73,6 +121,13 @@
             ],
             "index": "pypi",
             "version": "==2.8.1"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:a494d53b6d39c3c6e44c3bec237336e14305e4f29bbf800b599253057fbb79ed",
+                "sha256:c35965d010ce31b23eeb663ed3cc8c906275d6be1a34393a1d73a41febf4a048"
+            ],
+            "version": "==2020.1"
         },
         "requests": {
             "hashes": [
@@ -91,11 +146,11 @@
         },
         "tqdm": {
             "hashes": [
-                "sha256:00339634a22c10a7a22476ee946bbde2dbe48d042ded784e4d88e0236eca5d81",
-                "sha256:ea9e3fd6bd9a37e8783d75bfc4c1faf3c6813da6bd1c3e776488b41ec683af94"
+                "sha256:4733c4a10d0f2a4d098d801464bdaf5240c7dadd2a7fde4ee93b0a0efd9fb25e",
+                "sha256:acdafb20f51637ca3954150d0405ff1a7edde0ff19e38fb99a80a66210d2a28f"
             ],
             "index": "pypi",
-            "version": "==4.45.0"
+            "version": "==4.46.0"
         },
         "urllib3": {
             "hashes": [
@@ -122,10 +177,10 @@
         },
         "appdirs": {
             "hashes": [
-                "sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92",
-                "sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e"
+                "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41",
+                "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"
             ],
-            "version": "==1.4.3"
+            "version": "==1.4.4"
         },
         "attrs": {
             "hashes": [
@@ -500,29 +555,29 @@
         },
         "regex": {
             "hashes": [
-                "sha256:08119f707f0ebf2da60d2f24c2f39ca616277bb67ef6c92b72cbf90cbe3a556b",
-                "sha256:0ce9537396d8f556bcfc317c65b6a0705320701e5ce511f05fc04421ba05b8a8",
-                "sha256:1cbe0fa0b7f673400eb29e9ef41d4f53638f65f9a2143854de6b1ce2899185c3",
-                "sha256:2294f8b70e058a2553cd009df003a20802ef75b3c629506be20687df0908177e",
-                "sha256:23069d9c07e115537f37270d1d5faea3e0bdded8279081c4d4d607a2ad393683",
-                "sha256:24f4f4062eb16c5bbfff6a22312e8eab92c2c99c51a02e39b4eae54ce8255cd1",
-                "sha256:295badf61a51add2d428a46b8580309c520d8b26e769868b922750cf3ce67142",
-                "sha256:2a3bf8b48f8e37c3a40bb3f854bf0121c194e69a650b209628d951190b862de3",
-                "sha256:4385f12aa289d79419fede43f979e372f527892ac44a541b5446617e4406c468",
-                "sha256:5635cd1ed0a12b4c42cce18a8d2fb53ff13ff537f09de5fd791e97de27b6400e",
-                "sha256:5bfed051dbff32fd8945eccca70f5e22b55e4148d2a8a45141a3b053d6455ae3",
-                "sha256:7e1037073b1b7053ee74c3c6c0ada80f3501ec29d5f46e42669378eae6d4405a",
-                "sha256:90742c6ff121a9c5b261b9b215cb476eea97df98ea82037ec8ac95d1be7a034f",
-                "sha256:a58dd45cb865be0ce1d5ecc4cfc85cd8c6867bea66733623e54bd95131f473b6",
-                "sha256:c087bff162158536387c53647411db09b6ee3f9603c334c90943e97b1052a156",
-                "sha256:c162a21e0da33eb3d31a3ac17a51db5e634fc347f650d271f0305d96601dc15b",
-                "sha256:c9423a150d3a4fc0f3f2aae897a59919acd293f4cb397429b120a5fcd96ea3db",
-                "sha256:ccccdd84912875e34c5ad2d06e1989d890d43af6c2242c6fcfa51556997af6cd",
-                "sha256:e91ba11da11cf770f389e47c3f5c30473e6d85e06d7fd9dcba0017d2867aab4a",
-                "sha256:ea4adf02d23b437684cd388d557bf76e3afa72f7fed5bbc013482cc00c816948",
-                "sha256:fb95debbd1a824b2c4376932f2216cc186912e389bdb0e27147778cf6acb3f89"
+                "sha256:021a0ae4d2baeeb60a3014805a2096cb329bd6d9f30669b7ad0da51a9cb73349",
+                "sha256:04d6e948ef34d3eac133bedc0098364a9e635a7914f050edb61272d2ddae3608",
+                "sha256:099568b372bda492be09c4f291b398475587d49937c659824f891182df728cdf",
+                "sha256:0ff50843535593ee93acab662663cb2f52af8e31c3f525f630f1dc6156247938",
+                "sha256:1b17bf37c2aefc4cac8436971fe6ee52542ae4225cfc7762017f7e97a63ca998",
+                "sha256:1e2255ae938a36e9bd7db3b93618796d90c07e5f64dd6a6750c55f51f8b76918",
+                "sha256:2bc6a17a7fa8afd33c02d51b6f417fc271538990297167f68a98cae1c9e5c945",
+                "sha256:3ab5e41c4ed7cd4fa426c50add2892eb0f04ae4e73162155cd668257d02259dd",
+                "sha256:3b059e2476b327b9794c792c855aa05531a3f3044737e455d283c7539bd7534d",
+                "sha256:4df91094ced6f53e71f695c909d9bad1cca8761d96fd9f23db12245b5521136e",
+                "sha256:5493a02c1882d2acaaf17be81a3b65408ff541c922bfd002535c5f148aa29f74",
+                "sha256:5b741ecc3ad3e463d2ba32dce512b412c319993c1bb3d999be49e6092a769fb2",
+                "sha256:652ab4836cd5531d64a34403c00ada4077bb91112e8bcdae933e2eae232cf4a8",
+                "sha256:669a8d46764a09f198f2e91fc0d5acdac8e6b620376757a04682846ae28879c4",
+                "sha256:73a10404867b835f1b8a64253e4621908f0d71150eb4e97ab2e7e441b53e9451",
+                "sha256:7ce4a213a96d6c25eeae2f7d60d4dad89ac2b8134ec3e69db9bc522e2c0f9388",
+                "sha256:8127ca2bf9539d6a64d03686fd9e789e8c194fc19af49b69b081f8c7e6ecb1bc",
+                "sha256:b5b5b2e95f761a88d4c93691716ce01dc55f288a153face1654f868a8034f494",
+                "sha256:b7c9f65524ff06bf70c945cd8d8d1fd90853e27ccf86026af2afb4d9a63d06b1",
+                "sha256:f7f2f4226db6acd1da228adf433c5c3792858474e49d80668ea82ac87cf74a03",
+                "sha256:fa09da4af4e5b15c0e8b4986a083f3fd159302ea115a6cc0649cd163435538b8"
             ],
-            "version": "==2020.4.4"
+            "version": "==2020.5.7"
         },
         "requests": {
             "hashes": [
@@ -656,11 +711,11 @@
         },
         "tqdm": {
             "hashes": [
-                "sha256:00339634a22c10a7a22476ee946bbde2dbe48d042ded784e4d88e0236eca5d81",
-                "sha256:ea9e3fd6bd9a37e8783d75bfc4c1faf3c6813da6bd1c3e776488b41ec683af94"
+                "sha256:4733c4a10d0f2a4d098d801464bdaf5240c7dadd2a7fde4ee93b0a0efd9fb25e",
+                "sha256:acdafb20f51637ca3954150d0405ff1a7edde0ff19e38fb99a80a66210d2a28f"
             ],
             "index": "pypi",
-            "version": "==4.45.0"
+            "version": "==4.46.0"
         },
         "twine": {
             "hashes": [

--- a/bin/lm-zoo
+++ b/bin/lm-zoo
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding: utf-8
 
-from lm_zoo import lm_zoo
+from lm_zoo.commands import lm_zoo
 
 lm_zoo()

--- a/lm_zoo/commands.py
+++ b/lm_zoo/commands.py
@@ -1,0 +1,130 @@
+import sys
+
+import click
+import crayons
+import dateutil
+
+import lm_zoo as Z
+
+
+@click.group(help="``lm-zoo`` provides black-box access to computing with state-of-the-art language models.")
+def lm_zoo(): pass
+
+
+@lm_zoo.command()
+@click.option("--short", is_flag=True, default=False,
+              help="Output just a list of shortnames rather than a pretty list")
+def list(short):
+    """
+    List language models available in the central repository.
+    """
+    show_props = [
+        ("name", "Full name"),
+        ("ref_url", "Reference URL"),
+        ("maintainer", "Maintainer"),
+    ]
+
+    for model in Z.get_model_dict().values():
+        if short:
+            click.echo(model.shortname)
+        else:
+            click.echo(crayons.normal(model.shortname, bold=True))
+            click.echo("\t{0} {1}".format(
+                crayons.normal("Image URI: ", bold=True),
+                model.image_uri))
+
+            props = []
+            for key, label in show_props:
+                if hasattr(model, key):
+                    props.append((label, getattr(model, key)))
+
+            dt = dateutil.parser.isoparse(model.image["datetime"])
+            props.append(("Last updated", dt.strftime("%Y-%m-%d")))
+            props.append(("Size", "%.02fGB" % (model.image["size"] / 1024 / 1024 / 1024)))
+
+            for label, value in props:
+                click.echo("\t" + crayons.normal(label + ": ", bold=True)
+                            + value)
+
+def read_lines(fstream):
+    return [line.strip() for line in fstream]
+
+
+@lm_zoo.command()
+@click.argument("model", metavar="MODEL")
+@click.argument("in_file", type=click.File("r"), metavar="FILE")
+def tokenize(model, in_file):
+    """
+    Tokenize natural-language text according to a model's preprocessing
+    standards.
+
+    FILE should be a raw natural language text file with one sentence per line.
+
+    This command returns a text file with one tokenized sentence per line, with
+    tokens separated by single spaces. For each sentence, there is a one-to-one
+    mapping between the tokens output by this command and the tokens used by
+    the ``get-surprisals`` command.
+    """
+    sentences = read_lines(in_file)
+    sentences = Z.tokenize(model, sentences)
+    print("\n".join(" ".join(sentence) for sentence in sentences))
+
+
+@lm_zoo.command()
+@click.argument("model", metavar="MODEL")
+@click.argument("in_file", type=click.File("r"), metavar="FILE")
+def get_surprisals(model, in_file):
+    """
+    Get word-level surprisals from a language model for the given natural
+    language text. Tab-separated results will be sent to standard output,
+    following the format::
+
+      sentence_id	token_id	token	surprisal
+      1			1		This	0.000
+      1			2		is	1.000
+      1			3		a	1.000
+      1			4		<unk>	0.500
+      1			5		line	1.000
+      1			6		.	0.250
+      1			7		<eos>	0.100
+
+    The surprisal of a token :math:`w_i` is the negative logarithm of that
+    token's probability under a language model's predictive distribution:
+
+    .. math::
+        S(w_i) = -\log_2 p(w_i \mid w_1, w_2, \ldots, w_{i-1})
+
+    Note that surprisals are computed on the level of **tokens**, not words.
+    Models that insert extra tokens (e.g., an end-of-sentence token as above)
+    or which tokenize on the sub-word level (e.g. GPT2) will not have a
+    one-to-one mapping between rows of surprisal output from this command and
+    words.
+
+    There is guaranteed to be a one-to-one mapping, however, between the rows
+    of this file and the tokens produced by ``lm-zoo tokenize``.
+    """
+    sentences = read_lines(in_file)
+    ret = Z.get_surprisals(model, sentences)
+    ret.to_csv(sys.stdout, sep="\t")
+
+
+@lm_zoo.command()
+@click.argument("model", metavar="MODEL")
+@click.argument("in_file", type=click.File("r"), metavar="FILE")
+def unkify(model, in_file):
+    """
+    Detect unknown words for a language model for the given natural language
+    text.
+
+    FILE should be a raw natural language text file with one sentence per line.
+
+    This command returns a text file with one sentence per line, where each
+    sentence is represented as a sequence of ``0`` and ``1`` values. These
+    values correspond one-to-one with the model's tokenization of the sentence
+    (as returned by ``lm-zoo tokenize``). The value ``0`` indicates that the
+    corresponding token is in the model's vocabulary; the value ``1`` indicates
+    that the corresponding token is an unknown word for the model.
+    """
+    sentences = read_lines(in_file)
+    masks = Z.unkify(model, sentences)
+    print("\n".join(map(str, masks_i) for masks_i in masks))


### PR DESCRIPTION
I factored the `click` commands into a general `lm_zoo` model API. click commands are now defined in `lm_zoo.commands`. This allows us to define libraries on top of the lm-zoo commands.