### PR TITLE
add TinyLSTM model

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,6 +159,27 @@ jobs:
             #     name: Push to Docker Hub
             #     command: docker push cpllab/language-models:transformer-xl
 
+    tinylstm:
+        machine:
+            image: circleci/classic:latest
+        steps:
+            - checkout
+            - run:
+                name: Check for relevant code updates
+                command: ./scripts/check_for_updates.sh $CIRCLE_JOB << pipeline.git.base_revision >> << pipeline.git.revision >>
+
+            - run:
+                <<: *docker_login
+            - add_ssh_keys:
+                fingerprints:
+                    - "88:36:05:01:d6:98:05:43:e3:e4:e3:d3:a3:67:e9:29"
+            - run:
+                name: Build
+                command: docker build -t cpllab/language-models:tinylstm -f models/tinylstm/Dockerfile --build-arg CPL_SSH_PRV_KEY="$(cat ~/.ssh/id_rsa_88360501d6980543e3e4e3d3a367e929)" .
+            - run:
+                name: Run tests
+                command: docker run --rm -v `pwd`/test.py:/test.py -v `pwd`/docs/schemas:/schemas cpllab/language-models:tinylstm python /test.py
+
 
 
 workflows:
@@ -172,3 +193,4 @@ workflows:
             - ordered-neurons
             - gpt2
             - transformer-xl
+            - tinylstm

--- a/models/tinylstm/Dockerfile
+++ b/models/tinylstm/Dockerfile
@@ -1,0 +1,69 @@
+FROM alpine/git:latest as builder
+
+RUN mkdir -p /opt
+
+# Build arguments provide SSH keys for accessing private CPL data.
+ARG CPL_SSH_PRV_KEY
+RUN mkdir /root/.ssh && echo "StrictHostKeyChecking no" >> /root/.ssh/config \
+      && echo "$CPL_SSH_PRV_KEY" > /root/.ssh/id_rsa \
+      && chmod 600 /root/.ssh/id_rsa
+
+# Copy in source code.
+RUN git clone git://github.com/cpllab/tinylstm /opt/tinylstm
+
+# Copy in model parameters.
+ARG CHECKPOINT_NAME=bllip-lg_0111
+ARG CHECKPOINT_SOURCE=cpl@45.79.223.150:/home/cpl/tinylstm/checkpoints/$CHECKPOINT_NAME
+RUN mkdir -p /opt/tinylstm/checkpoint && \
+          scp -o "StrictHostKeyChecking=no" \
+            "${CHECKPOINT_SOURCE}/{model.pt,corpus.pt}" \
+            /opt/tinylstm/checkpoint
+# Remove SSH information.
+RUN rm -rf /root/.ssh
+
+
+
+FROM pytorch/pytorch:0.4.1-cuda9-cudnn7-runtime
+
+# Root of model directory relative to build context.
+ARG MODEL_ROOT=models/tinylstm
+
+COPY --from=builder /opt/tinylstm /opt/tinylstm
+
+RUN pip install -q nltk
+
+# Add test dependencies.
+RUN pip install nose jsonschema
+
+# Copy in shared tests.
+COPY test.py /opt/test.py
+
+# Copy external-facing scripts
+COPY ${MODEL_ROOT}/bin /opt/bin
+COPY shared/unkify /opt/bin/unkify
+COPY shared/spec /opt/bin/spec
+COPY shared/unsupported /opt/bin/get_predictions.hdf5
+
+ENV PATH "/opt/bin:${PATH}"
+
+ENV LMZOO_CHECKPOINT_PATH /opt/tinylstm/checkpoint
+ENV LMZOO_VOCABULARY_PATH vocab
+
+# Cache vocab list for easy access from `spec`, etc.
+RUN PYTHONPATH="/opt/tinylstm:$PYTHONPATH" python \
+                -c 'import os; import torch; corpus = torch.load(os.environ["LMZOO_CHECKPOINT_PATH"] + "/corpus.pt"); \
+                    f = open(os.path.join(os.environ["LMZOO_CHECKPOINT_PATH"], os.environ["LMZOO_VOCABULARY_PATH"]), "w"); f.write("\n".join(corpus.dictionary.idx2word))'
+
+# Current git commit of build repository
+ARG COMMIT
+# sha1 checksum of build directory
+ARG FILES_SHA1
+
+# Prepare spec.
+COPY ${MODEL_ROOT}/spec.template.json /tmp/spec.template.json
+RUN export BUILD_DATETIME="$(date)"
+RUN cat /tmp/spec.template.json | \
+            sed "s/<image\.sha1>/$COMMIT/g; s/<image\.files_sha1>/${FILES_SHA1}/g; s/<image\.datetime>/${BUILD_DATETIME}/g" \
+            > /opt/spec.template.json
+
+WORKDIR /opt/bin

--- a/models/tinylstm/bin/get_surprisals
+++ b/models/tinylstm/bin/get_surprisals
@@ -1,0 +1,13 @@
+#!/bin/sh
+MODEL_ROOT="/opt/tinylstm"
+MODEL_CHECKPOINT="${LMZOO_CHECKPOINT_PATH}/model.pt"
+MODEL_CORPUS="${LMZOO_CHECKPOINT_PATH}/corpus.pt"
+INPUT_FILE="$1"
+
+/opt/bin/tokenize $1 > /tmp/input_tokenized
+
+python ${MODEL_ROOT}/eval.py \
+    --checkpoint "$MODEL_CHECKPOINT" \
+    --corpus "$MODEL_CORPUS" \
+    --eval_data /tmp/input_tokenized \
+    --outf /dev/stdout

--- a/models/tinylstm/bin/tokenize
+++ b/models/tinylstm/bin/tokenize
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+import os
+from pathlib import Path
+import sys
+import codecs
+
+from nltk.tokenize import TreebankWordTokenizer
+
+tokenizer = TreebankWordTokenizer()
+
+checkpoint_path = Path(os.environ["LMZOO_CHECKPOINT_PATH"])
+vocab_path = checkpoint_path / Path(os.environ["LMZOO_VOCABULARY_PATH"])
+with vocab_path.open("r", encoding="utf-8") as f:
+    vocab = [line.strip() for line in f]
+
+sys.path.append("/opt/tinylstm")
+from get_raw import unkify
+
+for line in codecs.open(sys.argv[1], encoding="utf-8"):
+    tokens = tokenizer.tokenize(line.strip())
+    tokens = unkify(tokens, vocab)
+    print(" ".join(tokens))

--- a/models/tinylstm/spec.template.json
+++ b/models/tinylstm/spec.template.json
@@ -1,0 +1,34 @@
+{
+    "name": "tinylstm",
+    "ref_url": "https://github.com/cpllab/tinylstm",
+
+    "image": {
+        "maintainer": "jon@gauthiers.net",
+        "version": "<image.sha1>",
+        "checksum": "<image.files_sha1>",
+        "datetime": "<image.datetime>",
+        "supported_features": {
+            "tokenize": true,
+            "unkify": true,
+            "get_surprisals": true,
+            "get_predictions": false,
+            "mount_checkpoint": true
+        },
+        "gpu": {
+            "required": false,
+            "supported": false
+        }
+    },
+
+    "vocabulary": {
+        "unk_types": ["UNK", "UNK-CAPS", "UNK-CAPS-DASH", "UNK-CAPS-DASH-s", "UNK-CAPS-NUM", "UNK-CAPS-NUM-DASH", "UNK-CAPS-NUM-DASH-s", "UNK-CAPS-al", "UNK-CAPS-ed", "UNK-CAPS-er", "UNK-CAPS-est", "UNK-CAPS-ing", "UNK-CAPS-ion", "UNK-CAPS-ity", "UNK-CAPS-ly", "UNK-CAPS-s", "UNK-CAPS-y", "UNK-INITC", "UNK-INITC-DASH", "UNK-INITC-DASH-s", "UNK-INITC-KNOWNLC", "UNK-INITC-KNOWNLC-DASH", "UNK-INITC-KNOWNLC-DASH-s", "UNK-INITC-KNOWNLC-al", "UNK-INITC-KNOWNLC-ed", "UNK-INITC-KNOWNLC-er", "UNK-INITC-KNOWNLC-est", "UNK-INITC-KNOWNLC-ing", "UNK-INITC-KNOWNLC-ion", "UNK-INITC-KNOWNLC-ity", "UNK-INITC-KNOWNLC-ly", "UNK-INITC-KNOWNLC-s", "UNK-INITC-KNOWNLC-y", "UNK-INITC-NUM", "UNK-INITC-NUM-DASH", "UNK-INITC-NUM-DASH-s", "UNK-INITC-NUM-s", "UNK-INITC-al", "UNK-INITC-ed", "UNK-INITC-er", "UNK-INITC-est", "UNK-INITC-ing", "UNK-INITC-ion", "UNK-INITC-ity", "UNK-INITC-ly", "UNK-INITC-s", "UNK-INITC-y", "UNK-LC", "UNK-LC-DASH", "UNK-LC-DASH-s", "UNK-LC-NUM", "UNK-LC-NUM-DASH", "UNK-LC-NUM-DASH-s", "UNK-LC-NUM-s", "UNK-LC-al", "UNK-LC-ed", "UNK-LC-er", "UNK-LC-est", "UNK-LC-ing", "UNK-LC-ion", "UNK-LC-ity", "UNK-LC-ly", "UNK-LC-s", "UNK-LC-y", "UNK-NUM", "UNK-NUM-DASH"],
+        "prefix_types": [],
+        "suffix_types": ["<eos>"],
+        "special_types": []
+    },
+
+    "tokenizer": {
+        "type": "word",
+        "cased": true
+    }
+}


### PR DESCRIPTION
## Model

"Tiny LSTM" model used in recent ACL SyntaxGym papers. Based on PyTorch sample LSTM implementation. Relatively shallow stacked LSTM with dropout.

- **Are you the creator/co-creator of this language model?** No :)
- **Are you the creator/co-creator of this implementation of this language
   model?** Yes
- **Is this implementation the official implementation of the language model?** No
- **What licensing restrictions (if any) apply to this implementation of this
   language model?** None

## Training

- **What corpus was this model trained on?** BLLIP-LG as described in [Hu et al 2020][1]. 1.8M sentences, 42M tokens, 170K non-UNK types, 74 fine-grained UNK types.
- **What task was this model trained on?** next-word prediction

Complexity: 
- 2 layers
- 256 units per hidden layer
- 256 embedding units

Performance: 57.09 perplexity on held-out BLLIP-LG from [Hu et al 2020][1].

## Other notes

NB tests will probably fail, since this model supports the `mount_checkpoint` feature in advance of that feature being available on `develop`.

## Licensing

MIT

[1]: https://arxiv.org/abs/2005.03692
